### PR TITLE
Hide new scroll definition.

### DIFF
--- a/library/Hbro/Gui/MainView.hs
+++ b/library/Hbro/Gui/MainView.hs
@@ -59,7 +59,8 @@ import qualified Graphics.UI.Gtk.Builder                  as Gtk
 import           Graphics.UI.Gtk.General.General.Extended
 import qualified Graphics.UI.Gtk.Misc.Adjustment          as Gtk
 import           Graphics.UI.Gtk.Scrolling.ScrolledWindow
-import           Graphics.UI.Gtk.WebKit.DOM.Document
+import           Graphics.UI.Gtk.WebKit.DOM.Document      hiding
+                                                           (scroll)
 import           Graphics.UI.Gtk.WebKit.Extended          hiding
                                                            (LoadStatus (..),
                                                            networkRequestGetUri)


### PR DESCRIPTION
Graphics.UI.Gtk.WebKit.DOM.Document sprouted a new scroll function that
created an ambiguity in Hbro.Gui.MainView.  This change just hides it.

It doesn't seem to have any adverse effects when using older versions of
webkitgtk, either.