### PR TITLE
classy-prelude v1.x compatibility

### DIFF
--- a/library/Hbro.hs
+++ b/library/Hbro.hs
@@ -19,5 +19,5 @@ import           Hbro.IPC          as X
 -- import           Hbro.Keys.Model
 -- import           Hbro.Logger       as X
 -- import           Hbro.Options
-import           Hbro.Prelude      as X
+import           Hbro.Prelude      as X hiding (Handler)
 -- import           Hbro.WebView.Signals

--- a/library/Hbro/Boot.hs
+++ b/library/Hbro/Boot.hs
@@ -19,7 +19,8 @@ import           Hbro.IPC                        as IPC (CommandMap,
 import           Hbro.Keys                       as Keys
 import           Hbro.Logger
 import           Hbro.Options                    as Options
-import           Hbro.Prelude
+import           Hbro.Prelude                    hiding (async, withAsync,
+                                                  withAsyncBound)
 
 import           Control.Concurrent.Async.Lifted
 import           Control.Lens                    hiding ((<|), (??), (|>))

--- a/library/Hbro/Defaults.hs
+++ b/library/Hbro/Defaults.hs
@@ -22,7 +22,7 @@ import           Hbro.IPC
 import           Hbro.Keys                                as Keys
 import           Hbro.Keys.Model                          (singleKey, (.|))
 import           Hbro.Logger
-import           Hbro.Prelude
+import           Hbro.Prelude                             hiding (Handler)
 import           Hbro.WebView.Signals
 
 import           Control.Monad.Trans.Resource

--- a/library/Hbro/Event.hs
+++ b/library/Hbro/Event.hs
@@ -23,7 +23,7 @@ module Hbro.Event (
     ) where
 
 -- {{{ Imports
-import           Hbro.Prelude
+import           Hbro.Prelude                    hiding (Handler, async, cancel)
 
 import           Control.Concurrent.Async.Lifted
 import           Control.Concurrent.STM.TMChan

--- a/library/Hbro/Gui/PromptBar.hs
+++ b/library/Hbro/Gui/PromptBar.hs
@@ -40,7 +40,8 @@ import           Hbro.Event
 import           Hbro.Gdk.KeyVal
 import           Hbro.Gui.Builder
 import           Hbro.Logger
-import           Hbro.Prelude                             hiding (on)
+import           Hbro.Prelude                             hiding (async, on,
+                                                           throwM, throwOn)
 
 import           Control.Concurrent.Async.Lifted
 import           Control.Lens.Getter

--- a/library/Hbro/Keys.hs
+++ b/library/Hbro/Keys.hs
@@ -33,7 +33,7 @@ import           Hbro.Gdk.KeyVal
 import           Hbro.Keys.Model                 ((.|))
 import qualified Hbro.Keys.Model                 as Model
 import           Hbro.Logger
-import           Hbro.Prelude                    hiding (isPrefixOf)
+import           Hbro.Prelude                    hiding (async, isPrefixOf)
 
 import           Control.Concurrent.Async.Lifted
 import           Control.Monad.Trans.Resource

--- a/library/Hbro/Prelude.hs
+++ b/library/Hbro/Prelude.hs
@@ -29,8 +29,8 @@ module Hbro.Prelude
 import           ClassyPrelude                 as X hiding (Builder (..),
                                                      MonadReader (..),
                                                      ReaderT (..),
-                                                     defaultTimeLocale, error,
-                                                     log, toList)
+                                                     asks, defaultTimeLocale,
+                                                     error, log, tail, toList)
 
 import           Control.Applicative           as X (Alternative (..),
                                                      WrappedMonad, optional)

--- a/library/Hbro/WebView/Signals.hs
+++ b/library/Hbro/WebView/Signals.hs
@@ -11,7 +11,7 @@ import           Hbro.Gdk.KeyVal
 import           Hbro.Keys                                  as Keys
 import           Hbro.Keys.Model                            ((.|))
 import           Hbro.Logger
-import           Hbro.Prelude                               hiding (on)
+import           Hbro.Prelude                               hiding (on, throwM)
 
 import           Control.Monad.Catch
 import           Control.Monad.Trans.Maybe


### PR DESCRIPTION
Since v1.0, classy-prelude has added some exports which made hbro unable to build due to name clashes. This patch should make hbro compile again (works for me at least). No functional changes were made.